### PR TITLE
Fixed busy logic for SCA read/write commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ ALF(Alice Low-level Frontend) spawns DIM services as an interface with detector 
 ## Requirements
 In order to run ALF a DIM Nameserver has to be up and running. For performance reasons, it is recommended to run the DIM Nameserver on the host running the FRED server.
 
+## Install ALF
+Under the specified directory run: git clone https://github.com/AliceMCH/ALF.git
+cd ALF
+cmake3 -DInfoLogger_ROOT=/home/flp/alice/sw/slc7_x86-64/libInfoLogger/latest-o2-dataflow
+make all
+
 ## Usage
 
 ### o2-alf

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ ALF(Alice Low-level Frontend) spawns DIM services as an interface with detector 
 ## Requirements
 In order to run ALF a DIM Nameserver has to be up and running. For performance reasons, it is recommended to run the DIM Nameserver on the host running the FRED server.
 
-## Install ALF
-Under the specified directory run: git clone https://github.com/AliceMCH/ALF.git
-cd ALF
-cmake3 -DInfoLogger_ROOT=/home/flp/alice/sw/slc7_x86-64/libInfoLogger/latest-o2-dataflow
-make all
-
 ## Usage
 
 ### o2-alf

--- a/README.md
+++ b/README.md
@@ -7,14 +7,10 @@ ALF(Alice Low-level Frontend) spawns DIM services as an interface with detector 
 In order to run ALF a DIM Nameserver has to be up and running. For performance reasons, it is recommended to run the DIM Nameserver on the host running the FRED server.
 
 ## Install ALF
-Under the specified directory run: 
-
-`
-git clone https://github.com/AliceMCH/ALF.git
+Under the specified directory run: git clone https://github.com/AliceMCH/ALF.git
 cd ALF
 cmake3 -DInfoLogger_ROOT=/home/flp/alice/sw/slc7_x86-64/libInfoLogger/latest-o2-dataflow
 make all
-`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ Under the specified directory run:
 
 `
 git clone https://github.com/AliceMCH/ALF.git
+`
+`
 cd ALF
+`
+`
 cmake3 -DInfoLogger_ROOT=/home/flp/alice/sw/slc7_x86-64/libInfoLogger/latest-o2-dataflow
+`
+`
 make all
 `
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,12 @@ Under the specified directory run:
 `
 git clone https://github.com/AliceMCH/ALF.git
 `
-
 `
 cd ALF
 `
-
 `
 cmake3 -DInfoLogger_ROOT=/home/flp/alice/sw/slc7_x86-64/libInfoLogger/latest-o2-dataflow
 `
-
 `
 make all
 `

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ Under the specified directory run:
 `
 git clone https://github.com/AliceMCH/ALF.git
 `
+
 `
 cd ALF
 `
+
 `
 cmake3 -DInfoLogger_ROOT=/home/flp/alice/sw/slc7_x86-64/libInfoLogger/latest-o2-dataflow
 `
+
 `
 make all
 `

--- a/README.md
+++ b/README.md
@@ -7,10 +7,14 @@ ALF(Alice Low-level Frontend) spawns DIM services as an interface with detector 
 In order to run ALF a DIM Nameserver has to be up and running. For performance reasons, it is recommended to run the DIM Nameserver on the host running the FRED server.
 
 ## Install ALF
-Under the specified directory run: git clone https://github.com/AliceMCH/ALF.git
+Under the specified directory run: 
+
+`
+git clone https://github.com/AliceMCH/ALF.git
 cd ALF
 cmake3 -DInfoLogger_ROOT=/home/flp/alice/sw/slc7_x86-64/libInfoLogger/latest-o2-dataflow
 make all
+`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,8 @@ Under the specified directory run:
 
 `
 git clone https://github.com/AliceMCH/ALF.git
-`
-`
 cd ALF
-`
-`
 cmake3 -DInfoLogger_ROOT=/home/flp/alice/sw/slc7_x86-64/libInfoLogger/latest-o2-dataflow
-`
-`
 make all
 `
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Under the specified directory run:
 
 `
 git clone https://github.com/AliceMCH/ALF.git
+
+`
+cd ..
+`
+
+`
+. ./setup-QC.sh
 `
 
 `

--- a/README.md
+++ b/README.md
@@ -11,13 +11,6 @@ Under the specified directory run:
 
 `
 git clone https://github.com/AliceMCH/ALF.git
-
-`
-cd ..
-`
-
-`
-. ./setup-QC.sh
 `
 
 `


### PR DESCRIPTION
The current version of the SCA code has been probably derived directly from the previous official ALF distribution. However, doing tests for the MCH electronics we noticed that the busy logic is not robust, and we proposed some changes that did not land into the new code.

Both read and write commands should wait for the busy flag to be cleared before being executed.
In particular, the current implementation of the Sea::read() function stored the `command` variable only once, and then directly tests the channel busy state with `barRead(sc_regs::SCA_RD_CMD.index)`. When the busy is cleared, the initial value of the `command` variable is passed to the `checkError()` function, and an exception is thrown because the busy bit was still set when the `barRead(sc_regs::SCA_RD_CMD.index)` was initially called to set the `command` variable.

The proposed change in the busy logic guarantees that the `command` variable gets fresher at each loop, until the busy flag is cleared or the timeout is reached.