### PR TITLE
Bug fix: check argument instead of an undefined data member

### DIFF
--- a/src/Sca.cxx
+++ b/src/Sca.cxx
@@ -56,7 +56,7 @@ Sca::Sca(std::string cardId, int linkId)
 
 void Sca::init(const roc::Parameters::CardIdType& cardId, int linkId)
 {
-  if (mLink.linkId >= CRU_NUM_LINKS) {
+  if (linkId >= CRU_NUM_LINKS) {
     BOOST_THROW_EXCEPTION(
       ScaException() << ErrorInfo::Message("Maximum link number exceeded"));
   }


### PR DESCRIPTION
The init function is supposed to check that the linkId passed as an argument is within range.
If this is verified, the mLink data member is initialized.
But, due to what it looks like a bug, the uninitialized mLink.linkId is tested instead of the linkId argument, thus leading to random undefined behaviour.
Notice that a similar bug fix might be needed elsewhere (e.g. Swt.cxx)