### PR TITLE
MCH: fix crash in stop() function

### DIFF
--- a/src/Lla.cxx
+++ b/src/Lla.cxx
@@ -58,7 +58,9 @@ void LlaSession::start()
 
 void LlaSession::stop()
 {
-  mSession->stop();
+  if (mSession) {
+    mSession->stop();
+  }
 }
 
 } // namespace alf


### PR DESCRIPTION
The code crashes in the LlaSession destructor in the case when the LLA session is never started. In this case the mSession member is a null pointer, and the call to stop() in the destructor leads to a segmentation fault.