### PR TITLE
[MCH] IC: add delay before pulsing the READ

### DIFF
--- a/src/Ic.cxx
+++ b/src/Ic.cxx
@@ -90,6 +90,8 @@ uint32_t Ic::read(uint32_t address)
   barWrite(sc_regs::IC_WR_CMD.index, 0x8);
   barWrite(sc_regs::IC_WR_CMD.index, 0x0);
 
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
   // Pulse the READ
   barWrite(sc_regs::IC_WR_CMD.index, 0x2);
   barWrite(sc_regs::IC_WR_CMD.index, 0x0);


### PR DESCRIPTION
The IC read procedure requires a delay between the execution of the RD state machine and the READ pulse, otherwise one gets the back the value corresponding to the previous read command.

I have put a delay of 10 ms to match what is done in the write() function, however 1 ms seems to be enough to read back the correct values.